### PR TITLE
IIS in version different from EN translates the output

### DIFF
--- a/Example/Default.asp
+++ b/Example/Default.asp
@@ -5,8 +5,8 @@
 
 <%
 	' Register pages to test
-	Call ASPUnit.AddPage("/Example/TestAccount.asp")
-	Call ASPUnit.AddPage("/Example/TestAccountTransferService.asp")
+	Call ASPUnit.AddPage("TestAccount.asp")
+	Call ASPUnit.AddPage("TestAccountTransferService.asp")
 
 	' Execute tests
 	Call ASPUnit.Run()

--- a/Example/Default.asp
+++ b/Example/Default.asp
@@ -5,8 +5,8 @@
 
 <%
 	' Register pages to test
-	Call ASPUnit.AddPage("TestAccount.asp")
-	Call ASPUnit.AddPage("TestAccountTransferService.asp")
+	Call ASPUnit.AddPage("/Example/TestAccount.asp")
+	Call ASPUnit.AddPage("/Example/TestAccountTransferService.asp")
 
 	' Execute tests
 	Call ASPUnit.Run()

--- a/Lib/Classes/ASPUnitJSONResponder.asp
+++ b/Lib/Classes/ASPUnitJSONResponder.asp
@@ -98,11 +98,13 @@
 		End Function
 
 		Private Function JSONNumberPair(strName, varValue)
-			JSONNumberPair = JSONString(strName) & ":" & varValue
+			JSONNumberPair = JSONString(strName) & ":" & (FormatNumber(varValue, 0, -1, -1, -1))
 		End Function
 
 		Private Function JSONBooleanPair(strName, blnValue)
-			JSONBooleanPair = JSONString(strName) & ":" & LCase(blnValue)
+			Dim output : output = "true"
+			If Not blnValue Then output = "false"
+			JSONBooleanPair = JSONString(strName) & ":" & output
 		End Function
 
 		Private Function JSONStringEscape(strValue)


### PR DESCRIPTION
 Running aspunit from a IIS in Portuguese-BR version makes boolean values to be translated. It causes a parser error by showing the results because the "passed" property has the value "verdadeiro" instead of true.

I put a condicional that makes the output of JSONBooleanPair always being true/false.

Another problem was JSONNumberPair method output, because in Portuguese the decimal char separator is comma, not point. It breaks the JSON output and it causes a parsing error.
